### PR TITLE
Add MCrypt Library to Bash/php checker environment

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -2,6 +2,7 @@ FROM bash:4.4
 MAINTAINER Benjamin Manns <benjamin.manns@mni.thm.de>
 RUN apk add --no-cache php
 RUN apk add --no-cache php-json
+RUN apk add --no-cache php7-pecl-mcrypt
 RUN apk add --no-cache build-base
 RUN apk add --no-cache flex
 COPY similarity-tester-master /opt/sim


### PR DESCRIPTION
For php scriptfiles we need more libraries in order to fulfill certain checking tasks.
It is to be reminded, that those additional libraries add more time for the docker container to
start up, increasing the time the Server needs to respond.