### PR TITLE
implemented first test

### DIFF
--- a/ws/build.gradle
+++ b/ws/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     compile group: 'org.ldaptive', name: 'ldaptive', version: '1.2.4'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'au.com.bytecode', name: 'opencsv', version: '2.4'
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springVersion
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/ws/src/main/scala/de/thm/ii/fbs/util/DateParser.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/util/DateParser.scala
@@ -10,15 +10,11 @@ object DateParser {
   /**
     * Parse string to date
     * @author Benjamin Manns
-    * @param text a string containing a date
-    * @return parsed Date (LocalDate)
+    * @param text an ISO formatted date represented as a string
+    * @return An object of LocalDate
     */
   def dateParser(text: String): LocalDate = {
-    val patterns = List("yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd", "HH:mm:ss,", "dd/MM/uuuu",
-      "MMM dd, uuuu",
-      "dd MMMM uuuu",
-      "dd MMM uuuu",
-      "dd-MM-uuuu", "dd.MM.yyyy")
+    val patterns = List("yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd", "dd/MM/uuuu", "dd-MM-uuuu", "dd.MM.yyyy")
     val trimmedText = text.trim
     var date: LocalDate = null
     for (pattern <- patterns) {

--- a/ws/src/test/scala/de/thm/ii/fbs/util/DateParserTest.scala
+++ b/ws/src/test/scala/de/thm/ii/fbs/util/DateParserTest.scala
@@ -1,0 +1,81 @@
+package de.thm.ii.fbs.util
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.test.context.junit4.SpringRunner
+import java.time.{LocalDate, Month}
+import org.assertj.core.api.Assertions;
+
+/**
+  * Tests DateParser
+  *
+  * @author Andrej Sajenko
+  */
+@RunWith(classOf[SpringRunner])
+class DateParserTest {
+  /**
+    * Tests DateParser::dateParser
+    */
+  @Test
+  def dateParserTest01(): Unit = {
+    val isoDate = "2014-01-24 14:30:10"
+    val expectedParsedIsoDate = LocalDate.of(2014, Month.JANUARY, 24)
+    val currentParsedIsoDate = DateParser.dateParser(isoDate)
+    Assertions.assertThat(currentParsedIsoDate).isEqualTo(expectedParsedIsoDate)
+  }
+
+  /**
+    * Tests DateParser::dateParser
+    */
+  @Test
+  def dateParserTest02(): Unit = {
+    val isoDate = "2013-12-23"
+    val expectedParsedIsoDate = LocalDate.of(2013, Month.DECEMBER, 23)
+    val currentParsedIsoDate = DateParser.dateParser(isoDate)
+    Assertions.assertThat(currentParsedIsoDate).isEqualTo(expectedParsedIsoDate)
+  }
+
+  /**
+    * Tests DateParser::dateParser
+    */
+  @Test
+  def dateParserTest03(): Unit = {
+    val isoDate = "28/12/2013"
+    val expectedParsedIsoDate = LocalDate.of(2013, Month.DECEMBER, 28)
+    val currentParsedIsoDate = DateParser.dateParser(isoDate)
+    Assertions.assertThat(currentParsedIsoDate).isEqualTo(expectedParsedIsoDate)
+  }
+
+  /**
+    * Tests DateParser::dateParser
+    */
+  @Test
+  def dateParserTest04(): Unit = {
+    val isoDate = "21-12-2013"
+    val expectedParsedIsoDate = LocalDate.of(2013, Month.DECEMBER, 21)
+    val currentParsedIsoDate = DateParser.dateParser(isoDate)
+    Assertions.assertThat(currentParsedIsoDate).isEqualTo(expectedParsedIsoDate)
+  }
+
+  /**
+    * Tests DateParser::dateParser
+    */
+  @Test
+  def dateParserTest05(): Unit = {
+    val isoDate = "21.12.2013"
+    val expectedParsedIsoDate = LocalDate.of(2013, Month.DECEMBER, 21)
+    val currentParsedIsoDate = DateParser.dateParser(isoDate)
+    Assertions.assertThat(currentParsedIsoDate).isEqualTo(expectedParsedIsoDate)
+  }
+
+  /**
+    * Tests DateParser::dateParser
+    */
+  @Test
+  def dateParserTest06(): Unit = {
+    val isoDate = "21.12.2013"
+    val expectedParsedIsoDate = LocalDate.of(2013, Month.DECEMBER, 21)
+    val currentParsedIsoDate = DateParser.dateParser(isoDate)
+    Assertions.assertThat(currentParsedIsoDate).isEqualTo(expectedParsedIsoDate)
+  }
+}


### PR DESCRIPTION
Implemented first test for WS.
The test tests the unit class DateParser that supposes to transform date, represented as string, to java.time LocalDate object.
I have removed some date formats that we will never use in the application.