### PR TITLE
Fix TLS certificate validation for requests to the Master Runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - JWT_SECRET=8Dsupersecurekeydf0
       - BBB_SECRET
       - MASTER_RUNNER_URL=https://master-runner:8081
+      - MASTER_RUNNER_TLS_INSECURE=true
 
   master-runner:
     build: master-runner

--- a/ws/build.gradle
+++ b/ws/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     compile group: 'org.ldaptive', name: 'ldaptive', version: '1.2.4'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'au.com.bytecode', name: 'opencsv', version: '2.4'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springVersion
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mock-server', name: 'mockserver-netty', version: '3.10.8'

--- a/ws/src/main/resources/application.yml
+++ b/ws/src/main/resources/application.yml
@@ -41,6 +41,7 @@ services:
     shared-secret: ${BBB_SECRET:8Dsupersecurekeydf0}
   masterRunner:
     url: ${MASTER_RUNNER_URL:https://localhost:8081}
+    insecure: ${MASTER_RUNNER_TLS_INSECURE:false}
 spring:
   main:
     allow-bean-definition-overriding: true


### PR DESCRIPTION
This allows to disable TLS-Certificate validation for requests to the master runner. And thus allows to inform the master runner of a new submission even when it uses a self-signed certificate.
