### PR TITLE
Fix copy ws

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects { subproject ->
     version '1.0-SNAPSHOT'
 }
 
-task dist(dependsOn: ['ws:installDist', "master-runner:installDist", "web-gui:installDist"]) {
+task dist(dependsOn: ['ws:installDist', "master-runner:installDist", "web-gui:installDist", "web-gui:copyWebToWS"]) {
     doLast({
         installDist
     })

--- a/web-gui/build.gradle
+++ b/web-gui/build.gradle
@@ -39,11 +39,9 @@ distributions {
 // After build the ng app, we copy the dist content to or spring boot webservice static resoorce path
 // It will work on evry system, because of relative paths (at leat I hope so)
 
-task copyWebToWS(type:Copy, dependsOn: [build]) {
-  copy {
+task copyWebToWS(type: Copy, dependsOn: [build]) {
     from "${projectDir}/dist/${project.name}" // path from distributed web-gui
     into "${projectDir}/../ws/src/main/resources/static"
-  }
 }
 
 copyWebToWS


### PR DESCRIPTION
Fix copy ws to enable inclusion of the web-gui in ws when build with `gradle dist`.