### PR TITLE
Fix: config vars for production in config.json

### DIFF
--- a/master-runner/src/main/resources/config.json
+++ b/master-runner/src/main/resources/config.json
@@ -4,7 +4,7 @@
   "PFX_PASSWORD": "passwd",
   "PFX_PATH": "keystore.p12",
   "RESULT_SERVER_PORT": 443,
-  "RESULT_SERVER_HOST": "localhost",
+  "RESULT_SERVER_HOST": "http",
   "RESULT_SERVER_SSL": true,
   "RESULT_SERVER_TRUST_ALL": true,
   "RESULT_SERVER_VERIFY_HOST": false,
@@ -13,5 +13,5 @@
   "SQL_MAX_POOL_SIZE": 15,
   "SQL_SERVER_USERNAME": "root",
   "SQL_SERVER_PASSWORD": "SqfyBWhiFGr7FK60cVR2rel",
-  "SQL_SERVER_URL": "jdbc:mysql://localhost:3306"
+  "SQL_SERVER_URL": "jdbc:mysql://mysql2:3306"
 }


### PR DESCRIPTION
I think these changes need to be made for the master runner to address the http server and mysql2 database in production environment.