### PR TITLE
Fix conference with cas login

### DIFF
--- a/ws/src/main/scala/de/thm/ii/fbs/controller/LoginController.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/controller/LoginController.scala
@@ -66,6 +66,12 @@ class LoginController extends CasClientConfigurerAdapter {
           co.setHttpOnly(false)
           co.setMaxAge(30)
           response.addCookie(co)
+          val cr = new Cookie("JSESSIONID", "")
+          cr.setPath("/")
+          cr.setHttpOnly(true)
+          cr.setSecure(true)
+          cr.setMaxAge(0)
+          response.addCookie(cr)
         })
 
       response.setStatus(HttpServletResponse.SC_MOVED_TEMPORARILY)


### PR DESCRIPTION
This fixes #445.

Das Problem war, dass bei Verwendung des CAS-Logins der `JSESSIONID` Cookie gesetzt wird, welcher bei Verwendung des Konferenz-Features Probleme mit der Autorisierung der Websocket-Verbindungen verursacht.
