### PR TITLE
Renew token

### DIFF
--- a/web-gui/src/app/app.module.ts
+++ b/web-gui/src/app/app.module.ts
@@ -16,7 +16,7 @@ import {
   HttpInterceptor,
   HttpRequest, HttpResponse
 } from '@angular/common/http';
-import {JwtHelperService, JwtModule} from '@auth0/angular-jwt';
+import {JwtModule} from '@auth0/angular-jwt';
 import {Observable} from 'rxjs';
 import {DataprivacyDialogComponent} from './dialogs/dataprivacy-dialog/dataprivacy-dialog.component';
 import {ImpressumDialogComponent} from './dialogs/impressum-dialog/impressum-dialog.component';
@@ -26,15 +26,12 @@ import {MAT_DATE_LOCALE, MatNativeDateModule} from '@angular/material/core';
 import {MarkdownModule} from 'ngx-markdown';
 import {NgxDropzoneModule} from 'ngx-dropzone';
 import {MatSlideToggleModule} from '@angular/material/slide-toggle';
-//import { ImportCourseComponent } from './components/courses/import-course/import-course.component';
 import { ImportCourseComponent } from "./page-components/import-course/import-course.component";
 import {MatProgressBarModule} from '@angular/material/progress-bar';
 import { NewconferenceDialogComponent } from './dialogs/newconference-dialog/newconference-dialog.component';
-//import { ConferenceComponent } from './components/courses/detail-course/conference/conference.component';
 import {MatGridListModule} from '@angular/material/grid-list';
 import { NewticketDialogComponent } from './dialogs/newticket-dialog/newticket-dialog.component';
 import { IncomingCallDialogComponent } from './dialogs/incoming-call-dialog/incoming-call-dialog.component';
-// tslint:disable-next-line:max-line-length
 import {MatSelectModule} from '@angular/material/select';
 import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatSliderModule} from '@angular/material/slider';

--- a/web-gui/src/app/app.module.ts
+++ b/web-gui/src/app/app.module.ts
@@ -14,9 +14,9 @@ import {
   HttpEvent,
   HttpHandler,
   HttpInterceptor,
-  HttpRequest
+  HttpRequest, HttpResponse
 } from '@angular/common/http';
-import {JwtModule} from '@auth0/angular-jwt';
+import {JwtHelperService, JwtModule} from '@auth0/angular-jwt';
 import {Observable} from 'rxjs';
 import {DataprivacyDialogComponent} from './dialogs/dataprivacy-dialog/dataprivacy-dialog.component';
 import {ImpressumDialogComponent} from './dialogs/impressum-dialog/impressum-dialog.component';
@@ -85,16 +85,24 @@ import {
   NgxMatTimepickerModule
 } from '@angular-material-components/datetime-picker';
 import { InfoComponent } from './tool-components/info/info.component';
+import { tap } from 'rxjs/operators';
+import {AuthService} from "./service/auth.service";
 
 @Injectable()
 export class ApiURIHttpInterceptor implements HttpInterceptor {
+  constructor(private authService: AuthService) {}
   public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const clonedRequest: HttpRequest<any> = req.clone({
       //url: (req.url.search('localhost') >= 0) ? req.url : 'https://localhost'  + req.url // 'https://fk-server.mni.thm.de'
       //url: 'https://feedback.mni.thm.de/'  + req.url // 'https://fk-server.mni.thm.de'
     });
 
-    return next.handle(clonedRequest);
+    return next.handle(clonedRequest).pipe(tap(event => {
+      if (event instanceof HttpResponse) {
+        const response = <HttpResponse<any>>event;
+        this.authService.renewToken(response)
+      }
+    }));
   }
 }
 

--- a/web-gui/src/app/service/auth.service.ts
+++ b/web-gui/src/app/service/auth.service.ts
@@ -82,7 +82,10 @@ export class AuthService {
    */
   public renewToken(response: HttpResponse<any>) {
     const token = this.extractTokenFromHeader(response)
-    this.storeToken(token)
+    if (token && !this.jwtHelper.isTokenExpired(token)) {
+      this.storeToken(token)
+      console.log("Refresh token: " + token)
+    }
   }
 
   private login(username: string, password: string, uri: string): Observable<JWTToken> {
@@ -110,7 +113,7 @@ export class AuthService {
 
   private extractTokenFromHeader(response: HttpResponse<Succeeded>): string {
     const authHeader: string = response.headers.get('Authorization');
-    return authHeader.replace('Bearer ', '');
+    return authHeader ? authHeader.replace('Bearer ', '') : null;
   }
 
   /**


### PR DESCRIPTION
We got the hint that the users role is only updated after he logout and in again.
I wrote a hook that looks in all response messages from HttpClient, retrieves the JWT token
that is located in the response (if exists) and stores the new token by overwriting the old one.
Since the token stores the users role, it should be updated with any interaction with the server that uses the HttpClient.