### PR TITLE
 master-runner additional information

### DIFF
--- a/master-runner/src/main/scala/de/thm/ii/fbs/services/ExtendedResultsService.scala
+++ b/master-runner/src/main/scala/de/thm/ii/fbs/services/ExtendedResultsService.scala
@@ -1,0 +1,51 @@
+package de.thm.ii.fbs.services
+
+import io.vertx.core.json.JsonObject
+import io.vertx.lang.scala.json.JsonArray
+import io.vertx.scala.ext.sql.ResultSet
+
+/**
+  * Generate all ExtendedResult json
+  *
+  * @author Max Stephan
+  */
+object ExtendedResultsService {
+  private val COMPARE_TABLE_TYPE = "compareTable"
+
+  private def buildTableJson(resultSet: Option[ResultSet]) = {
+    val table = new JsonObject
+
+    if (resultSet.isDefined) {
+      /* Transform Result set to json structure */
+      val expectedHead = new JsonArray()
+      resultSet.get.getColumnNames.foreach(n => expectedHead.add(n))
+      val expectedRes = new JsonArray()
+      resultSet.get.getResults.foreach(r => expectedRes.add(r))
+
+      table
+        .put("head", expectedHead)
+        .put("rows", expectedRes)
+    } else {
+      table
+    }
+  }
+
+  /**
+    * Generates the Json Structure for the type `CompareTable`
+    *
+    * @param results SQL Runner results
+    * @return Json structure
+    */
+  def buildCompareTable(results: (Option[ResultSet], Option[ResultSet])): Option[JsonObject] = {
+    val res = new JsonObject
+    val expectedTable = buildTableJson(results._1)
+    val resultTable = buildTableJson(results._2)
+
+    res
+      .put("type", COMPARE_TABLE_TYPE)
+      .put("expected", expectedTable)
+      .put("result", resultTable)
+
+    if (results._1.isEmpty && results._2.isEmpty) None else Option(res)
+  }
+}

--- a/master-runner/src/main/scala/de/thm/ii/fbs/verticles/runner/SqlRunnerVerticle.scala
+++ b/master-runner/src/main/scala/de/thm/ii/fbs/verticles/runner/SqlRunnerVerticle.scala
@@ -72,7 +72,7 @@ class SqlRunnerVerticle extends ScalaVerticle {
           val res = sqlRunner.compareResults(value)
           logger.info(s"Submission-${runArgs.submission.id} Finished\nSuccess: ${res._2} \nMsg: ${res._1}")
 
-          vertx.eventBus().send(HttpVerticle.SEND_COMPLETION, Option(SQLRunnerService.transformResult(runArgs, res._2, res._1, "")))
+          vertx.eventBus().send(HttpVerticle.SEND_COMPLETION, Option(SQLRunnerService.transformResult(runArgs, res._2, res._1, "", (res._3, Option(value._2)))))
 
         case Failure(ex: SQLException) =>
           // TODO not throw exception from config failures (not include informations)
@@ -92,6 +92,6 @@ class SqlRunnerVerticle extends ScalaVerticle {
 
   private def handleError(runArgs: RunArgs, msg: String): Unit = {
     logger.info(s"Submission-${runArgs.submission.id} Finished\nSuccess: false \nMsg: $msg")
-    vertx.eventBus().send(HttpVerticle.SEND_COMPLETION, Option(SQLRunnerService.transformResult(runArgs, success = false, "", msg)))
+    vertx.eventBus().send(HttpVerticle.SEND_COMPLETION, Option(SQLRunnerService.transformResult(runArgs, success = false, "", msg, (None, None))))
   }
 }

--- a/master-runner/src/main/scala/de/thm/ii/fbs/verticles/runner/SqlRunnerVerticle.scala
+++ b/master-runner/src/main/scala/de/thm/ii/fbs/verticles/runner/SqlRunnerVerticle.scala
@@ -74,13 +74,13 @@ class SqlRunnerVerticle extends ScalaVerticle {
 
           vertx.eventBus().send(HttpVerticle.SEND_COMPLETION, Option(SQLRunnerService.transformResult(runArgs, res._2, res._1, "", (res._3, Option(value._2)))))
 
-        case Failure(ex: SQLException) =>
-          // TODO not throw exception from config failures (not include informations)
-          handleError(runArgs, s"Es gab eine SQLException: ${ex.getMessage.replaceAll("[1-9][0-9]*_[a-z0-9]+_db\\.", "")}")
-        case Failure(ex: RunnerException) =>
-          handleError(runArgs, ex.getMessage)
         case Failure(ex: SQLTimeoutException) =>
           handleError(runArgs, s"Das Query hat zu lange gedauert: ${ex.getMessage}")
+        case Failure(ex: SQLException) =>
+          // TODO not throw exception from config failures (not include informations)
+          handleError(runArgs, s"Es gab eine SQLException: ${ex.getMessage.replaceAll("[0-9]*_[0-9]*_[a-z]*\\.", "")}")
+        case Failure(ex: RunnerException) =>
+          handleError(runArgs, ex.getMessage)
         case Failure(ex) =>
           handleError(runArgs, s"Der SQL Runner hat einen Fehler geworfen: ${ex.getMessage}.")
       })

--- a/master-runner/swagger.yml
+++ b/master-runner/swagger.yml
@@ -130,6 +130,8 @@ components:
       type: object
       required:
         - exitCode
+        - stdout
+        - stderr
       properties:
         exitCode:
           type: integer
@@ -140,3 +142,6 @@ components:
         stderr:
           type: string
           description: The standart Error Output of the Runner
+        extInfo:
+          type: string
+          description: Extended Result informations

--- a/swagger.yml
+++ b/swagger.yml
@@ -1613,6 +1613,11 @@ components:
         configurationId:
           type: integer
           description: The configuration id of the checker configuration
+        extInfo:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Extended information of the check
     CheckerConfig:
       type: object
       required:

--- a/ws/src/main/resources/fbs.sql
+++ b/ws/src/main/resources/fbs.sql
@@ -188,6 +188,7 @@ CREATE TABLE IF NOT EXISTS `fbs`.`checker_result` (
   `configuration_id` INT NOT NULL,
   `exit_code` INT NOT NULL DEFAULT 1,
   `result_text` TEXT NOT NULL DEFAULT '',
+  `ext_info` JSON,
   PRIMARY KEY (`submission_id`, `configuration_id`),
   INDEX `configuration_id_fk_idx` (`configuration_id` ASC) VISIBLE,
   CONSTRAINT `submussuibn_id_fk`

--- a/ws/src/main/scala/de/thm/ii/fbs/controller/ResultController.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/controller/ResultController.scala
@@ -1,10 +1,10 @@
 package de.thm.ii.fbs.controller
 
 import com.fasterxml.jackson.databind.JsonNode
-import de.thm.ii.fbs.services.persistance.{CheckerConfigurationService, StorageService, SubmissionService, TaskService}
+import de.thm.ii.fbs.services.persistance.SubmissionService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.{CrossOrigin, GetMapping, PathVariable, PostMapping, RequestBody, RequestMapping, RestController}
+import org.springframework.web.bind.annotation._
 
 /**
   * Result controller implement routes for submitting results
@@ -17,14 +17,18 @@ class ResultController {
   private val submissionService: SubmissionService = null
 
   /**
-    * Handels the result request from the runner
-    * @param sid the submission id
-    * @param ccid the checker configuration id
+    * Handles the result request from the runner
+    *
+    * @param sid     the submission id
+    * @param ccid    the checker configuration id
     * @param request the request body
     */
   @PostMapping(value = Array("/results/{sid}/{ccid}", "/api/v1/results/{sid}/{ccid}"), consumes = Array(MediaType.APPLICATION_JSON_VALUE))
   def postResult(@PathVariable("sid") sid: Int, @PathVariable("ccid") ccid: Int, @RequestBody request: JsonNode): Unit = {
-    submissionService.storeResult(sid, ccid, request.get("exitCode").asInt(0),
-      request.get("stdout").asText("") + request.get("stderr").asText(""))
+    submissionService.storeResult(
+      sid, ccid, request.get("exitCode").asInt(0),
+      request.get("stdout").asText("") + request.get("stderr").asText(""),
+      if (request.hasNonNull("extInfo")) request.get("extInfo").toString else null
+    )
   }
 }

--- a/ws/src/main/scala/de/thm/ii/fbs/model/CheckResult.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/model/CheckResult.scala
@@ -1,10 +1,14 @@
 package de.thm.ii.fbs.model
 
+import com.fasterxml.jackson.databind.JsonNode
+
 /**
   * Check result of a single check
-  * @param exitCode Exit code of the check
-  * @param resultText Output text of the checker
-  * @param checkerType The cheker type that checked the submission
+  *
+  * @param exitCode        Exit code of the check
+  * @param resultText      Output text of the checker
+  * @param checkerType     The checker type that checked the submission
   * @param configurationId Checker configuration id
+  * @param extInfo         Checker extended information
   */
-case class CheckResult(exitCode: Int = 1, resultText: String, checkerType: String, configurationId: Int)
+case class CheckResult(exitCode: Int = 1, resultText: String, checkerType: String, configurationId: Int, extInfo: JsonNode)

--- a/ws/src/main/scala/de/thm/ii/fbs/services/persistance/SubmissionService.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/persistance/SubmissionService.scala
@@ -76,14 +76,16 @@ class SubmissionService {
 
   /**
     * Stores a result
-    * @param sid The submission id
-    * @param ccid The check runner configuration id
-    * @param exitCode The exit Code of the runner
+    *
+    * @param sid        The submission id
+    * @param ccid       The check runner configuration id
+    * @param exitCode   The exit Code of the runner
     * @param resultText The resultText of the runner
+    * @param extInfo    Extended runner information
     */
-  def storeResult(sid: Int, ccid: Int, exitCode: Int, resultText: String): Unit =
-    DB.insert("INSERT INTO checker_result (submission_id, configuration_id, exit_code, result_text) " +
-      "VALUES (?, ?, ?, ?)", sid, ccid, exitCode, resultText)
+  def storeResult(sid: Int, ccid: Int, exitCode: Int, resultText: String, extInfo: String): Unit =
+    DB.insert("INSERT INTO checker_result (submission_id, configuration_id, exit_code, result_text, ext_info) " +
+      "VALUES (?, ?, ?, ?, ?)", sid, ccid, exitCode, resultText, extInfo)
 
   /**
     * Removes all results stored for this submission


### PR DESCRIPTION
I have added the extended runner information as described in  #466 (Currently only for the SQL Runner).

The requests for the submissions (e.g.: `/api/v1/{uid}/courses/{cid}/tasks/{tid}/submissions`) now contain, if you have the correct permissions, the extended information (if there are none or you don't have the permissions, these are `null`).