### PR TITLE
Change: Make all Conferences and Users public by default

### DIFF
--- a/ws/src/main/scala/de/thm/ii/fbs/model/Participant.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/model/Participant.scala
@@ -10,7 +10,7 @@ import org.json.JSONObject
   * @param visible visibility state
   * @author Andrej Sajenko
   */
-case class Participant(user: User, role: CourseRole.Value, visible: Boolean = false) {
+case class Participant(user: User, role: CourseRole.Value, visible: Boolean = true) {
   /**
     * visibility state of User in Conference component
     */

--- a/ws/src/main/scala/de/thm/ii/fbs/services/conferences/conference/BBBConference.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/conferences/conference/BBBConference.scala
@@ -24,7 +24,7 @@ class BBBConference(override val id: String, override val courseId: Int,
   /**
     * The visibility of the Conference
     */
-  override var isVisible: Boolean = false
+  override var isVisible: Boolean = true
 
   /**
     * Gets the url to the Conference


### PR DESCRIPTION
After reviewing the feedback systems functionality with a group of students, it became clear that being invisible upon entering and not seeing oneself is unintuitive for many users and raises concern if it functions properly.