### PR TITLE
Change deadline format from unix time to iso 8601

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1566,8 +1566,8 @@ components:
         description:
           type: string
         deadline:
-          type: number
-          description: Unix time as long
+          type: string
+          description: ISO-8601 time as string
         mediaType:
           type: string
           description: The media type for the submissions according to RFC 4288

--- a/web-gui/src/app/dialogs/task-new-dialog/task-new-dialog.component.ts
+++ b/web-gui/src/app/dialogs/task-new-dialog/task-new-dialog.component.ts
@@ -26,7 +26,7 @@ export class TaskNewDialogComponent implements OnInit {
   isUpdate: boolean;
   courseId: number;
   task: Task = {
-    deadline: Date.now(),
+    deadline: new Date().toISOString(),
     description: '',
     mediaType: '',
     name: ''
@@ -94,6 +94,6 @@ export class TaskNewDialogComponent implements OnInit {
   }
 
   addDate(event: MatDatepickerInputEvent<Date>) {
-    this.task.deadline = event.value.valueOf();
+    this.task.deadline = event.value.toISOString();
   }
 }

--- a/web-gui/src/app/model/Task.ts
+++ b/web-gui/src/app/model/Task.ts
@@ -2,6 +2,6 @@ export interface Task {
   id?: number;
   name: string;
   description?: string;
-  deadline: number;
+  deadline: string;
   mediaType?: string;
 }

--- a/ws/src/main/scala/de/thm/ii/fbs/controller/TaskController.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/controller/TaskController.scala
@@ -1,5 +1,6 @@
 package de.thm.ii.fbs.controller
 
+import java.text.SimpleDateFormat
 import java.util.Date
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -83,11 +84,12 @@ class TaskController {
 
     if (user.globalRole == GlobalRole.ADMIN || user.globalRole == GlobalRole.MODERATOR || privilegedByCourse) {
       ( body.retrive("name").asText(),
-        body.retrive("deadline").asLong(),
+        body.retrive("deadline").asText(),
         body.retrive("mediaType").asText(),
         body.retrive("description").asText()
       ) match {
-        case (Some(name), Some(deadline), Some(mediaType), desc) => taskService.create(cid, Task(name, new Date(deadline), mediaType, desc.getOrElse("")))
+        case (Some(name), Some(deadline), Some(mediaType), desc) => taskService.create(cid,
+          Task(name, deadline, mediaType, desc.getOrElse("")))
         case _ => throw new BadRequestException("Malformed Request Body")
       }
     } else {
@@ -112,11 +114,12 @@ class TaskController {
 
     if (user.globalRole == GlobalRole.ADMIN || user.globalRole == GlobalRole.MODERATOR || privilegedByCourse) {
       ( body.retrive("name").asText(),
-        body.retrive("deadline").asLong(),
+        body.retrive("deadline").asText(),
         body.retrive("mediaType").asText(),
         body.retrive("description").asText()
       ) match {
-        case (Some(name), Some(deadline), Some(mediaType), desc) => taskService.update(cid, tid, Task(name, new Date(deadline), mediaType, desc.getOrElse("")))
+        case (Some(name), Some(deadline), Some(mediaType), desc) => taskService.update(cid, tid,
+          Task(name, deadline, mediaType, desc.getOrElse("")))
         case _ => throw new BadRequestException("Malformed Request Body")
       }
     } else {

--- a/ws/src/main/scala/de/thm/ii/fbs/model/Task.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/model/Task.scala
@@ -10,4 +10,4 @@ import java.util.Date
   * @param description The description of that task
   * @param id The id of the task, if 0,  then no id was assigned
   */
-case class Task(name: String, deadline: Date, mediaType: String, description: String = "", id: Int = 0)
+case class Task(name: String, deadline: String, mediaType: String, description: String = "", id: Int = 0)

--- a/ws/src/main/scala/de/thm/ii/fbs/services/persistance/TaskService.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/persistance/TaskService.scala
@@ -3,10 +3,11 @@ package de.thm.ii.fbs.services.persistance
 import java.math.BigInteger
 import java.sql
 import java.sql.{ResultSet, SQLException}
+import java.text.SimpleDateFormat
 import java.util.Date
 
 import de.thm.ii.fbs.model.Task
-import de.thm.ii.fbs.util.DB
+import de.thm.ii.fbs.util.{DB, ISO8601}
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Component
@@ -47,7 +48,7 @@ class TaskService {
   def create(cid: Int, task: Task): Task =
     DB.insert("INSERT INTO task (name, media_type, description, deadline, course_id) VALUES (?, ?, ?, ?, ?);",
       task.name, task.mediaType, task.description,
-      new sql.Date(task.deadline.getTime), cid)
+      new sql.Date(ISO8601.simpleDateFormat.parse(task.deadline).getTime), cid)
       .map(gk => gk(0).asInstanceOf[BigInteger].intValue())
       .flatMap(id => getOne(id)) match {
       case Some(task) => task
@@ -63,7 +64,7 @@ class TaskService {
     */
   def update(cid: Int, tid: Int, task: Task): Boolean =
     1 == DB.update("UPDATE task SET name = ?, media_type = ?, description = ?, deadline = ? WHERE task_id = ? AND course_id = ?",
-      task.name, task.mediaType, task.description, new sql.Date(task.deadline.getTime), tid, cid)
+      task.name, task.mediaType, task.description, new sql.Date(ISO8601.simpleDateFormat.parse(task.deadline).getTime), tid, cid)
 
   /**
     * Delete a task by id
@@ -78,7 +79,7 @@ class TaskService {
     name = res.getString("name"),
     mediaType = res.getString("media_type"),
     description = res.getString("description"),
-    deadline = new Date(res.getDate("deadline").getTime),
+    deadline = ISO8601.simpleDateFormat.format(new Date(res.getDate("deadline").getTime)),
     id = res.getInt("task_id")
   )
 }

--- a/ws/src/main/scala/de/thm/ii/fbs/services/persistance/TaskService.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/persistance/TaskService.scala
@@ -2,7 +2,7 @@ package de.thm.ii.fbs.services.persistance
 
 import java.math.BigInteger
 import java.sql
-import java.sql.{ResultSet, SQLException}
+import java.sql.{ResultSet, SQLException, Timestamp}
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -48,7 +48,7 @@ class TaskService {
   def create(cid: Int, task: Task): Task =
     DB.insert("INSERT INTO task (name, media_type, description, deadline, course_id) VALUES (?, ?, ?, ?, ?);",
       task.name, task.mediaType, task.description,
-      new sql.Date(ISO8601.simpleDateFormat.parse(task.deadline).getTime), cid)
+      new Timestamp(ISO8601.simpleDateFormat.parse(task.deadline).getTime), cid)
       .map(gk => gk(0).asInstanceOf[BigInteger].intValue())
       .flatMap(id => getOne(id)) match {
       case Some(task) => task
@@ -64,7 +64,7 @@ class TaskService {
     */
   def update(cid: Int, tid: Int, task: Task): Boolean =
     1 == DB.update("UPDATE task SET name = ?, media_type = ?, description = ?, deadline = ? WHERE task_id = ? AND course_id = ?",
-      task.name, task.mediaType, task.description, new sql.Date(ISO8601.simpleDateFormat.parse(task.deadline).getTime), tid, cid)
+      task.name, task.mediaType, task.description, new Timestamp(ISO8601.simpleDateFormat.parse(task.deadline).getTime), tid, cid)
 
   /**
     * Delete a task by id
@@ -79,7 +79,7 @@ class TaskService {
     name = res.getString("name"),
     mediaType = res.getString("media_type"),
     description = res.getString("description"),
-    deadline = ISO8601.simpleDateFormat.format(new Date(res.getDate("deadline").getTime)),
+    deadline = ISO8601.simpleDateFormat.format(new Date(res.getTimestamp("deadline").getTime)),
     id = res.getInt("task_id")
   )
 }

--- a/ws/src/main/scala/de/thm/ii/fbs/util/ISO8601.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/util/ISO8601.scala
@@ -1,0 +1,12 @@
+package de.thm.ii.fbs.util
+import java.text.SimpleDateFormat
+
+/**
+  * Contains the ISO601 format
+  */
+object ISO8601 {
+  /**
+    * The ISO601 format
+    */
+  val simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+}


### PR DESCRIPTION
This pull request changes the api format of the deadline from a Unix timestamp to iso 8601.
In addition, the time of the deadline is now also stored in the database, not just the date.

Closes #482
