### PR TITLE
Deployment error

### DIFF
--- a/ci/docker-deploy.sh
+++ b/ci/docker-deploy.sh
@@ -17,9 +17,10 @@ function dockerPush(){
 }
 
 echo "START DOCKER DEPLOY"
-docker-compose build
 
-docker login --password $DOCKER_PWD  --username $DOCKER_LOGIN
+echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
+
+docker-compose build
 
 echo "DOCKER IMAGES"
 docker images


### PR DESCRIPTION
resolves #507 

Due to the rate limits introduced by Docker Hub, it is necessary to log in before creating the Docker containers, otherwise required containers will not be downloaded.