### PR TITLE
[CI/CD] run script with bash

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,7 +51,7 @@ jobs:
           contains(github.ref, 'master') ||
           contains(github.ref, 'dev') ||
           startsWith(github.ref, 'refs/tags/v')
-        run: sh ./ci/docker-deploy.sh ${GITHUB_REF##*/}
+        run: bash ./ci/docker-deploy.sh ${GITHUB_REF##*/}
         env:
           DOCKER_LOGIN: ${{ secrets.DOCKER_LOGIN }}
           DOCKER_PWD: ${{ secrets.DOCKER_PWD }}


### PR DESCRIPTION
The deployment script must be executed with `bash` and not with `sh`.

---

Fix for #555 