### PR TITLE
Add analysis routes

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -31,6 +31,8 @@ tags:
     description: Legally obligatory documents and checks
   - name: Result
     description: Incomming checker results
+  - name: Analysis
+    description: Routes to query data for analysis purposes
 paths:
   /login/cas:
     post:
@@ -1883,6 +1885,42 @@ paths:
           description: Forbidden
         "404":
           description: Not Found
+  "/analysis/courses/{cid}/results/{tid}":
+    get:
+      security:
+        - JWT: [ ]
+      tags:
+        - Analysis
+      summary: Get anonymised results of a course from an task
+      parameters:
+        - name: cid
+          in: path
+          description: course id
+          required: true
+          schema:
+            type: integer
+        - name: tid
+          in: path
+          description: Task id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          headers:
+            Authorization:
+              description: Bearer
+              schema:
+                type: string
+          content:
+            "application/json":
+              schema:
+                $ref: '#/components/schemas/AnalysisCourseResult'
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
 servers:
   - url: https://feedback.mni.thm.de/api/v1
 components:
@@ -2131,6 +2169,32 @@ components:
                 type: integer
               passed:
                 type: boolean
+    AnalysisCourseResult:
+      type: array
+      items:
+        type: object
+        required:
+          - submission
+          - passed
+          - resultText
+          - userId
+          - attempt
+        properties:
+          submission:
+            type: string
+            description: The submission of the user
+          passed:
+            type: boolean
+            description: Was the task passed?
+          resultText:
+            type: string
+            description: The result of the test
+          userId:
+            type: integer
+            description: An identification number for the user. However, this does not correspond to the correct userId, but is incremented during creation.
+          attempt:
+            type: integer
+            description: Attempt number
     EvaluationResults:
       type: array
       items:

--- a/ws/src/main/scala/de/thm/ii/fbs/controller/AnalysisController.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/controller/AnalysisController.scala
@@ -1,0 +1,49 @@
+package de.thm.ii.fbs.controller
+
+import de.thm.ii.fbs.controller.exception.ForbiddenException
+import de.thm.ii.fbs.model.{CourseRole, GlobalRole, AnalysisCourseResult}
+import de.thm.ii.fbs.services.evaluation.EvaluationResultService
+import de.thm.ii.fbs.services.persistence.{CourseRegistrationService, CourseResultService, EvaluationContainerService}
+import de.thm.ii.fbs.services.security.AuthService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.web.bind.annotation.{CrossOrigin, GetMapping, PathVariable, RequestMapping, ResponseBody, RestController}
+
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+/**
+  * Routes to query data for analysis purposes
+  */
+@RestController
+@CrossOrigin
+@RequestMapping(path = Array("/api/v1/analysis"))
+class AnalysisController {
+  @Autowired
+  private val authService: AuthService = null
+  @Autowired
+  private val courseResultService: CourseResultService = null
+  @Autowired
+  private val courseRegistration: CourseRegistrationService = null
+
+  /**
+    * Get anonymised results of a course from an task.
+    * @param cid Course id
+    * @param tid Task id
+    * @param req request
+    * @param res response
+    * @return A list of course results
+    */
+  @GetMapping(value = Array("/courses/{cid}/results/{tid}"))
+  @ResponseBody
+  def getCourseResultsByTask(@PathVariable cid: Int, @PathVariable tid: Int, req: HttpServletRequest, res: HttpServletResponse): List[AnalysisCourseResult] = {
+    val user = authService.authorize(req, res)
+
+    val privilegedByCourse = courseRegistration.getParticipants(cid).find(_.user.id == user.id)
+      .exists(p => p.role == CourseRole.DOCENT || p.role == CourseRole.TUTOR)
+
+    if (privilegedByCourse || user.globalRole == GlobalRole.ADMIN || user.globalRole == GlobalRole.MODERATOR) {
+      courseResultService.getAllByTask(cid, tid)
+    } else {
+      throw new ForbiddenException()
+    }
+  }
+}

--- a/ws/src/main/scala/de/thm/ii/fbs/model/AnalysisCourseResult.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/model/AnalysisCourseResult.scala
@@ -1,0 +1,12 @@
+package de.thm.ii.fbs.model
+
+/**
+  *  Anomized results of a course from an task
+  * @param submission The submission of the user
+  * @param passed Was the task passed?
+  * @param resultText The result of the test
+  * @param userId An identification number for the user.
+  *               However, this does not correspond to the correct userId, but is incremented during creation.
+  * @param attempt Attempt number
+  */
+case class AnalysisCourseResult(var submission: String = "", passed: Boolean, resultText: String, userId: Int, attempt: Int)

--- a/ws/src/main/scala/de/thm/ii/fbs/services/persistence/CourseResultService.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/persistence/CourseResultService.scala
@@ -23,7 +23,6 @@ class CourseResultService {
   @Autowired
   private val storageService: StorageService = null
 
-
   /**
     * Get All Course Results
     * @param cid Course id

--- a/ws/src/main/scala/de/thm/ii/fbs/services/persistence/CourseResultService.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/persistence/CourseResultService.scala
@@ -1,7 +1,7 @@
 package de.thm.ii.fbs.services.persistence
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import de.thm.ii.fbs.model.{CourseResult, TaskResult}
+import de.thm.ii.fbs.model.{CourseResult, AnalysisCourseResult, TaskResult}
 import de.thm.ii.fbs.util.DB
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
@@ -20,13 +20,16 @@ class CourseResultService {
   private val courseRegistration: CourseRegistrationService = null
   @Autowired
   private val objectMapper: ObjectMapper = null
+  @Autowired
+  private val storageService: StorageService = null
+
 
   /**
     * Get All Course Results
     * @param cid Course id
     * @return all Course Results
     */
-def getAll(cid: Int): List[CourseResult] = DB.query("""
+  def getAll(cid: Int): List[CourseResult] = DB.query("""
     |select u.user_id
     |     ,u.prename
     |     ,u.surname
@@ -68,8 +71,31 @@ def getAll(cid: Int): List[CourseResult] = DB.query("""
     |order by u.user_id;
     |""".stripMargin, (res, _) => parseResult(res), cid)
 
+  /**
+    * Get All Course Results by a Task
+    * @param cid Course id
+    * @param tid Task id
+    * @return all Course Results
+    */
+  def getAllByTask(cid: Int, tid: Int): List[AnalysisCourseResult] = DB.query("""
+      |select submission_id, task_id, DENSE_RANK() OVER(order by user_id) as user_id,
+      |ROW_NUMBER() OVER(PARTITION BY user_id ORDER BY submission_time) as attempt,
+      |not exit_code as passed, result_text from user_task_submission
+      |join checker_result using (submission_id)
+      |join task using (task_id) where course_id = ? and task_id = ?
+      |group by submission_id order by submission_time;
+      |""".stripMargin, (res, _) => parseByTaskResult(res), cid, tid)
+
   private def parseResult(res: ResultSet): CourseResult = CourseResult(
     courseRegistration.parseUserResult(res), res.getBoolean("passed"),
     objectMapper.readValue(res.getString("results"), classOf[Array[TaskResult]]).toList.sorted
+  )
+
+  private def parseByTaskResult(res: ResultSet): AnalysisCourseResult = AnalysisCourseResult(
+    submission = storageService.getSolutionFile(res.getInt("submission_id")),
+    passed = res.getBoolean("passed"),
+    resultText = res.getString("result_text"),
+    userId = res.getInt("user_id"),
+    attempt = res.getInt("attempt")
   )
 }

--- a/ws/src/main/scala/de/thm/ii/fbs/services/persistence/StorageService.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/persistence/StorageService.scala
@@ -1,11 +1,12 @@
 package de.thm.ii.fbs.services.persistence
 
-import java.io.IOException
+import java.io.{File, IOException}
 import java.nio.file._
-
 import org.apache.commons.io.FileUtils
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+
+import scala.io.Source
 
 /**
   * Handles file of tasks and submissions.
@@ -18,6 +19,20 @@ class StorageService {
 
   private def tasksDir(tid: Int) = uploadDirPath.resolve("tasks").resolve(String.valueOf(tid))
   private def submissionDir(sid: Int) = uploadDirPath.resolve("submissions").resolve(String.valueOf(sid))
+
+  private def getFileContent(path: Option[Path]): String = {
+    if (path.isDefined) {
+      val source = Source.fromFile(path.get.toFile)
+
+      try {
+        source.mkString
+      } finally {
+        source.close()
+      }
+    } else {
+      ""
+    }
+  }
 
   /**
     * Store (replace if exists) the main file of a task
@@ -69,6 +84,13 @@ class StorageService {
     * @return The path to the file
     */
   def pathToSolutionFile(sid: Int): Option[Path] = Option(submissionDir(sid).resolve("solution-file")).filter(Files.exists(_))
+
+  /**
+    * Gets the Content of the solution file
+    * @param sid Submission id
+    * @return The Solution file content
+    */
+  def getSolutionFile(sid: Int): String = getFileContent(pathToSolutionFile(sid))
 
   /**
     * Delete a main file


### PR DESCRIPTION
Adds a route to get all the results for a task (`/analysis/courses/{cid}/results/{tid}`). These do not contain any personal user information as they are only to be used for data analysis.