### PR TITLE
[Bug] Remove development configuration from proxy setup

### DIFF
--- a/web-gui/src/app/app.module.ts
+++ b/web-gui/src/app/app.module.ts
@@ -89,7 +89,6 @@ export class ApiURIHttpInterceptor implements HttpInterceptor {
     const clonedRequest: HttpRequest<any> = req.clone({
       // url: (req.url.search('localhost') >= 0) ? req.url : 'https://localhost'  + req.url // 'https://fk-server.mni.thm.de'
       // url: 'https://feedback.mni.thm.de/'  + req.url // 'https://fk-server.mni.thm.de'
-      url: 'https://localhost' + req.url
     });
 
     return next.handle(clonedRequest).pipe(tap(event => {


### PR DESCRIPTION
In the PR #573 a proxy configuration was pushed by mistake which should only be present in the development process.