### PR TITLE
Fix classroom HTTPS call

### DIFF
--- a/ws/src/main/scala/de/thm/ii/fbs/services/classroom/ClassroomService.scala
+++ b/ws/src/main/scala/de/thm/ii/fbs/services/classroom/ClassroomService.scala
@@ -36,7 +36,7 @@ class ClassroomService(templateBuilder: RestTemplateBuilder,
                        courseService: CourseService,
                        courseRegistrationService: CourseRegistrationService
                 ) {
-  private val restTemplate: RestTemplate = RestTemplateFactory.makeRestTemplate(insecure)
+  private val restTemplate = new RestTemplate()
 
   private val classrooms = mutable.HashMap[Int, DigitalClassroom]()
 


### PR DESCRIPTION
Switch to default Spring RestTemplate instead of Apache implementation.
The default RestTemplate accepts the valid SSL certificate. Which is fine, because it is a valid, signed CA-issued certificate.