### PR TITLE
Remove exposed ports from mysql container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       MYSQL_DATABASE: fbs
     volumes:
       - ./data/mysql1:/var/lib/mysql
-    ports:
-      - "3306:3306"
     networks:
       fbs:
 


### PR DESCRIPTION
Remove port mapping from `docker-compose.yaml` to prevent regressions during deployment.