### PR TITLE
[CODEOWNERS] move default owners to the top

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
+*                             @thm-mni-ii/feedbacksystem-mods
 modules/fbs-core/web/*        @thm-mni-ii/feedbacksystem-frontend-mods
 modules/fbs-core/api/*        @thm-mni-ii/feedbacksystem-api-mods
 modules/fbs-runner/checker/*  @thm-mni-ii/feedbacksystem-datenanalyse-mods
@@ -7,5 +8,3 @@ scripts/ci/*                  @thm-mni-ii/feedbacksystem-api-mods
 docker-compose.yml            @thm-mni-ii/feedbacksystem-api-mods
 
 .github/*                     @thm-mni-ii/feedbacksystem-admins
-
-*                             @thm-mni-ii/feedbacksystem-mods


### PR DESCRIPTION
The default owners must be defined at the beginning of the file (see [github docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)). 