### PR TITLE
[CI] Update `tibdex/github-app-token` version

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@36464acb844fc53b9b8b2401da68844f6b05ebb0
+        uses: tibdex/github-app-token@v1.6.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PEM }}


### PR DESCRIPTION
The current used version (Copied from the github-docs) does not exsist.

---

follow up #741 