### PR TITLE
added optional parameters to confirm-dialog-component

### DIFF
--- a/modules/fbs-core/web/src/app/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/modules/fbs-core/web/src/app/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -2,8 +2,8 @@
 <mat-dialog-content>{{ data.message }}</mat-dialog-content>
 <mat-dialog-actions>
   <button mat-flat-button color="accent" (click)="confirm(false)">
-    Abbrechen
+    {{data.closeText || "Abbrechen"}}
   </button>
   &nbsp; &nbsp;
-  <button mat-flat-button color="warn" (click)="confirm(true)">Ja</button>
+  <button mat-flat-button color="warn" (click)="confirm(true)">{{data.confirmText || "Ja"}}</button>
 </mat-dialog-actions>

--- a/modules/fbs-core/web/src/app/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/modules/fbs-core/web/src/app/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -8,7 +8,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 })
 export class ConfirmDialogComponent {
   constructor(
-    @Inject(MAT_DIALOG_DATA) public data: { title: string; message: string },
+    @Inject(MAT_DIALOG_DATA) public data: { title: string; message: string, confirmText?: string, closeText?: string },
     public dialogRef: MatDialogRef<ConfirmDialogComponent>
   ) {}
 


### PR DESCRIPTION
resolves #718 

There is already a dialog (confirm-dialog) that can be used to confirm actions. I added optional parameters, so devs can customize text for the confirm and close button. 