### PR TITLE
[CI/CD]  Add a Pull request verifier

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,15 @@
+{
+  "LABEL": {
+    "name": "Invalid title",
+    "color": "d93f0b"
+  },
+  "CHECKS": {
+    "regexp": "^(?!i?[0-9]).*",
+    "ignoreLabels": ["Pull request Verifier: ignore"]
+  },
+  "MESSAGES": {
+    "success": "OK",
+    "failure": "Invalid Pull request title",
+    "notice": "The Pull request title should not be the same as the Branch name"
+  }
+}

--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,7 +4,7 @@
     "color": "d93f0b"
   },
   "CHECKS": {
-    "regexp": "^(?!i?[0-9]).*",
+    "regexp": "^(?![iI]?[0-9]).*",
     "ignoreLabels": ["Pull request Verifier: ignore"]
   },
   "MESSAGES": {

--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -10,6 +10,6 @@
   "MESSAGES": {
     "success": "OK",
     "failure": "Invalid Pull request title",
-    "notice": "The Pull request title should not be the same as the Branch name"
+    "notice": "The title of the pull request should not start with a number or an i followed by a number"
   }
 }

--- a/.github/workflows/pull-request-verifier.yml
+++ b/.github/workflows/pull-request-verifier.yml
@@ -1,0 +1,20 @@
+name: "Pull request Verifier"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Title
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.3.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
This PR adds a CI/CD that checks the title of a pull request and fails if it starts with `i<number>` or `<number>`. This check is to prevent PRs with the default name (name of the branch) from being merged (as happened in #775 and #768), as this would make for an unpleasant commit message.