### PR TITLE
add release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,40 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - duplicate
+      - wontfix
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Fixed bugs 🐞
+      labels:
+        - bug
+    - title: New core Features 🎉
+      labels:
+        - enhancement
+        - "fbs-core: api"
+        - "fbs-core: web"
+    - title: New checker Features 🎉
+      labels:
+        - enhancement
+        - "checker: bash"
+        - "checker: sql"
+        - "checker: excel"
+        - "checker: sap"
+        - "fbs-runner: checker"
+    - title: New checker-api Features 🎉
+      labels:
+        - checker-api
+    - title: Dependency updates ⬆️
+      labels: 
+        - dependencies
+    - title: Internal 🔒
+      labels:
+        - "CI/CD"
+        - Docker
+        - internal
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,7 +18,6 @@ changelog:
         - "fbs-core: web"
     - title: New checker Features 🎉
       labels:
-        - enhancement
         - "checker: bash"
         - "checker: sql"
         - "checker: excel"


### PR DESCRIPTION
Adding a configuration for the github relase notes (see [Github Docs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes))