### PR TITLE
[Web] Mark tasks as "mandatory", "bonus/additional", etc.

### DIFF
--- a/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.html
+++ b/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.html
@@ -62,9 +62,9 @@
     <!-- Task Mediatype -->
     <mat-form-field class="col">
       <mat-label>Verbindlichkeit</mat-label>
-      <mat-select formControlName="liability">
+      <mat-select formControlName="requirementType">
         <mat-option value="mandatory">Pflicht</mat-option>
-        <mat-option value="bonus">Bonus</mat-option>
+        <mat-option value="optional">Bonus</mat-option>
       </mat-select>
     </mat-form-field>
 

--- a/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.html
+++ b/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.html
@@ -59,6 +59,15 @@
       </mat-select>
     </mat-form-field>
 
+    <!-- Task Mediatype -->
+    <mat-form-field class="col">
+      <mat-label>Verbindlichkeit</mat-label>
+      <mat-select formControlName="liability">
+        <mat-option value="mandatory">Pflicht</mat-option>
+        <mat-option value="bonus">Bonus</mat-option>
+      </mat-select>
+    </mat-form-field>
+
     <div *ngIf="taskForm.value.mediaType === 'application/x-spreadsheet'">
       <mat-form-field class="col" (click)="fileInput.click()">
         <input

--- a/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.ts
+++ b/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.ts
@@ -22,7 +22,7 @@ import { CheckerConfig } from "../../model/CheckerConfig";
 import { CheckerFileType } from "src/app/enums/checkerFileType";
 
 const defaultMediaType = "text/plain";
-const defaultLiability = "mandatory"
+const defaultrequirement = "mandatory";
 
 /**
  * Dialog to create or update a task
@@ -38,7 +38,7 @@ export class TaskNewDialogComponent implements OnInit {
     description: new UntypedFormControl(""),
     deadline: new UntypedFormControl(this.getDefaultDeadline()),
     mediaType: new UntypedFormControl(defaultMediaType),
-    liability: new UntypedFormControl(defaultLiability),
+    requirementType: new UntypedFormControl(defaultrequirement),
     exelFile: new UntypedFormControl(""),
     userIDField: new UntypedFormControl(""),
     inputFields: new UntypedFormControl(""),
@@ -54,6 +54,7 @@ export class TaskNewDialogComponent implements OnInit {
     mediaType: "",
     name: "",
     mediaInformation: null,
+    requirementType: "",
   };
 
   spreadsheet: File = null;
@@ -89,6 +90,7 @@ export class TaskNewDialogComponent implements OnInit {
   getValues() {
     this.task.name = this.taskForm.get("name").value;
     this.task.description = this.taskForm.get("description").value;
+    this.task.requirementType = this.taskForm.get("requirementType").value;
     this.task.mediaType = this.taskForm.get("mediaType").value;
     if (this.task.mediaType === "application/x-spreadsheet") {
       this.task.mediaInformation = {
@@ -108,6 +110,9 @@ export class TaskNewDialogComponent implements OnInit {
     this.taskForm.controls["name"].setValue(this.task.name);
     this.taskForm.controls["description"].setValue(this.task.description);
     this.taskForm.controls["mediaType"].setValue(this.task.mediaType);
+    this.taskForm.controls["requirementType"].setValue(
+      this.task.requirementType
+    );
     this.taskForm.controls["deadline"].setValue(new Date(this.task.deadline));
     if (this.task.mediaType === "application/x-spreadsheet") {
       this.taskForm.controls["exelFile"].setValue("loading...");

--- a/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.ts
+++ b/modules/fbs-core/web/src/app/dialogs/task-new-dialog/task-new-dialog.component.ts
@@ -21,6 +21,7 @@ import { CheckerService } from "../../service/checker.service";
 import { CheckerConfig } from "../../model/CheckerConfig";
 
 const defaultMediaType = "text/plain";
+const defaultLiability = "mandatory"
 
 /**
  * Dialog to create or update a task
@@ -36,6 +37,7 @@ export class TaskNewDialogComponent implements OnInit {
     description: new UntypedFormControl(""),
     deadline: new UntypedFormControl(this.getDefaultDeadline()),
     mediaType: new UntypedFormControl(defaultMediaType),
+    liability: new UntypedFormControl(defaultLiability),
     exelFile: new UntypedFormControl(""),
     userIDField: new UntypedFormControl(""),
     inputFields: new UntypedFormControl(""),

--- a/modules/fbs-core/web/src/app/model/Task.ts
+++ b/modules/fbs-core/web/src/app/model/Task.ts
@@ -3,6 +3,7 @@ export interface Task {
   name: string;
   description?: string;
   deadline: string;
+  requirementType: string;
   mediaType?: string;
   mediaInformation?:
     | SpreadsheetMediaInformation

--- a/modules/fbs-core/web/src/app/page-components/course-detail/task-preview/task-preview.component.html
+++ b/modules/fbs-core/web/src/app/page-components/course-detail/task-preview/task-preview.component.html
@@ -6,7 +6,7 @@
   <span
     >{{ task.name }}
     <span *ngIf="task.requirementType == 'mandatory'">&nbsp; (Pflicht)</span
-    ><span *ngIf="task.requirementType == 'additional'"
+    ><span *ngIf="task.requirementType == 'optional'"
       >&nbsp; (Bonus)</span
     ></span
   >

--- a/modules/fbs-core/web/src/app/page-components/course-detail/task-preview/task-preview.component.html
+++ b/modules/fbs-core/web/src/app/page-components/course-detail/task-preview/task-preview.component.html
@@ -5,8 +5,8 @@
 >
   <span
     >{{ task.name }}
-    <span *ngIf="task.requirementType == 'mandatory'">&nbsp; (Pflicht)</span
-    ><span *ngIf="task.requirementType == 'optional'"
+    <span *ngIf="task.requirementType === 'mandatory'">&nbsp; (Pflicht)</span
+    ><span *ngIf="task.requirementType === 'optional'"
       >&nbsp; (Bonus)</span
     ></span
   >

--- a/modules/fbs-core/web/src/app/page-components/course-detail/task-preview/task-preview.component.html
+++ b/modules/fbs-core/web/src/app/page-components/course-detail/task-preview/task-preview.component.html
@@ -3,7 +3,13 @@
   class="task-container"
   id="{{ task.id }}"
 >
-  <span>{{ task.name }}</span>
+  <span
+    >{{ task.name }}
+    <span *ngIf="task.requirementType == 'mandatory'">&nbsp; (Pflicht)</span
+    ><span *ngIf="task.requirementType == 'additional'"
+      >&nbsp; (Bonus)</span
+    ></span
+  >
   <span class="meta">
     <mat-icon class="material-icons" color="accent">access_time</mat-icon>
     <span class="tiny">{{ task.deadline | date: "dd.MM.yyyy HH:mm" }}</span>


### PR DESCRIPTION
resolves #704 

If the task is mandatory, the user sees this:
![image](https://user-images.githubusercontent.com/104082549/194541566-aa0ba8da-f7c2-47fc-8aa5-19e40fc7d764.png)

and this, if it's bonus:
![image](https://user-images.githubusercontent.com/104082549/194541739-0e6e5cb0-f04e-40b1-9a20-4052de34627f.png)

While creating or updating a task, the lecturer can choose "Pflicht" or "Bonus":
![image](https://user-images.githubusercontent.com/104082549/194541920-709f762f-3afc-4d2d-b156-bbd2bf4a2ced.png)

