### PR TITLE
[API] Parse JSON null values as None

### DIFF
--- a/modules/fbs-core/api/src/main/scala/de/thm/ii/fbs/util/JsonWrapper.scala
+++ b/modules/fbs-core/api/src/main/scala/de/thm/ii/fbs/util/JsonWrapper.scala
@@ -4,51 +4,66 @@ import com.fasterxml.jackson.databind.JsonNode
 
 /**
   * Allow save retrivement of textrual attributes.
+  *
   * @param jsonNode Wrapp json
   */
 class JsonWrapper(jsonNode: JsonNode) {
   /**
     * @return Return textual representation of the node or none
     */
-  def asText(): Option[String] = if (jsonNode != null) Option(jsonNode.asText()) else Option.empty
+  def asText(): Option[String] = if (isNotNull) Option(jsonNode.asText()) else Option.empty
+
   /**
     * @return Return integer representation of the node or none
     */
-  def asInt(): Option[Int] = if (jsonNode != null) Option(jsonNode.asInt()) else Option.empty
+  def asInt(): Option[Int] = if (isNotNull) Option(jsonNode.asInt()) else Option.empty
+
   /**
     * @return Return boolean representation of the node or none
     */
-  def asBool(): Option[Boolean] = if (jsonNode != null) Option(jsonNode.asBoolean()) else Option.empty
+  def asBool(): Option[Boolean] = if (isNotNull) Option(jsonNode.asBoolean()) else Option.empty
+
   /**
     * @return Return long representation of the node or none
     */
-  def asLong(): Option[Long] = if (jsonNode != null) Option(jsonNode.asLong()) else Option.empty
+  def asLong(): Option[Long] = if (isNotNull) Option(jsonNode.asLong()) else Option.empty
 
   /**
     * @return Return a json object or none
     */
-  def asObject(): Option[JsonNode] = if (jsonNode != null) Option(jsonNode) else Option.empty
+  def asObject(): Option[JsonNode] = if (isNotNull) Option(jsonNode) else Option.empty
+
   /**
     * Retrive a key from json object if the json object is not null
+    *
     * @param key Key to access
     * @return JsonWrapper
     */
   def retrive(key: String): JsonWrapper = {
-    if (jsonNode != null) {
+    if (isNotNull) {
       new JsonWrapper(jsonNode.get(key))
     } else {
       this
     }
   }
+
+  /**
+    * Check if the json node is not null and not of type NullNode
+    */
+  private def isNotNull = {
+    jsonNode != null && !jsonNode.isNull
+  }
 }
 
 /**
   * Conversion object for com.fasterxml.jackson.databind.JsonNode
+  *
   * @author Andrej Sajenko
   */
 object JsonWrapper {
   /**
     * Converts to json wrapper.
+    *
     * @param jsonNode JsonNode from faster xml jackson
     * @return The wrapper.
     */

--- a/modules/fbs-core/api/src/test/scala/de/thm/ii/fbs/util/JsonWrapperTest.scala
+++ b/modules/fbs-core/api/src/test/scala/de/thm/ii/fbs/util/JsonWrapperTest.scala
@@ -1,0 +1,148 @@
+package de.thm.ii.fbs.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import de.thm.ii.fbs.util.JsonWrapper.jsonNodeToWrapper
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.test.context.junit4.SpringRunner
+
+/**
+  * Tests JsonWrapper
+  *
+  * @author Max Stephan
+  */
+@RunWith(classOf[SpringRunner])
+class JsonWrapperTest {
+  val mapper = new ObjectMapper()
+
+  /**
+    * Tests JsonWrapper As Text
+    *
+    */
+  @Test
+  def jsonWrapperTestAsText(): Unit = {
+    val json = getJsonObj
+    val expected = Option("test")
+    val res = json.retrive("string").asText()
+
+    Assertions.assertThat(res).isEqualTo(expected)
+  }
+
+  /**
+    * Tests JsonWrapper As Int
+    *
+    */
+  @Test
+  def jsonWrapperTestAsInt(): Unit = {
+    val json = getJsonObj
+    val expected = Option(1)
+    val res = json.retrive("int").asInt()
+
+    Assertions.assertThat(res).isEqualTo(expected)
+  }
+
+  /**
+    * Tests JsonWrapper As Bool
+    *
+    */
+  @Test
+  def jsonWrapperTestAsBool(): Unit = {
+    val json = getJsonObj
+    val expected = Option(true)
+    val res = json.retrive("bool").asBool()
+
+    Assertions.assertThat(res).isEqualTo(expected)
+  }
+
+  /**
+    * Tests JsonWrapper As Long
+    *
+    */
+  @Test
+  def jsonWrapperTestAsLong(): Unit = {
+    val json = getJsonObj
+    val expected = Option(1.toLong)
+    val res = json.retrive("long").asLong()
+
+    Assertions.assertThat(res).isEqualTo(expected)
+  }
+
+  private def getJsonObj = {
+    val json = mapper.createObjectNode()
+    json.put("string", "test")
+    json.putNull("emptyString")
+
+    json.put("int", 1)
+    json.putNull("emptyInt")
+
+    json.put("bool", true)
+    json.putNull("emptyBool")
+
+    json.put("long", 1.toLong)
+    json.putNull("emptyLong")
+
+    json.putNull("null")
+  }
+
+  /**
+    * Tests JsonWrapper with Null values
+    *
+    */
+  @Test
+  def jsonWrapperTestNull(): Unit = {
+    val json = getJsonObj
+    val expected = Option.empty
+    val resString = json.retrive("emptyString").asText()
+    val resInt = json.retrive("emptyInt").asInt()
+    val resBool = json.retrive("emptyBool").asBool()
+    val resLong = json.retrive("emptyLong").asLong()
+
+    Assertions.assertThat(resString).isEqualTo(expected)
+    Assertions.assertThat(resInt).isEqualTo(expected)
+    Assertions.assertThat(resBool).isEqualTo(expected)
+    Assertions.assertThat(resLong).isEqualTo(expected)
+  }
+
+  /**
+    * Tests JsonWrapper with invalid Key
+    *
+    */
+  @Test
+  def jsonWrapperTestNotPresent(): Unit = {
+    val json = getJsonObj
+    val expected = Option.empty
+    val resString = json.retrive("noString").asBool()
+    val resInt = json.retrive("noInt").asBool()
+    val resBool = json.retrive("noBool").asBool()
+    val resLong = json.retrive("noLong").asBool()
+
+    Assertions.assertThat(resString).isEqualTo(expected)
+    Assertions.assertThat(resInt).isEqualTo(expected)
+    Assertions.assertThat(resBool).isEqualTo(expected)
+    Assertions.assertThat(resLong).isEqualTo(expected)
+  }
+
+  /**
+    * Tests JsonWrapper with null
+    *
+    */
+  @Test
+  def jsonWrapperTestRetriveNull(): Unit = {
+    val json = new JsonWrapper(null)
+
+    Assertions.assertThat(json.retrive("test")).isEqualTo(json)
+  }
+
+  /**
+    * Tests JsonWrapper with null
+    *
+    */
+  @Test
+  def jsonWrapperTestRetriveNullNode(): Unit = {
+    val nullNode = getJsonObj.get("null")
+    val json = new JsonWrapper(nullNode)
+
+    Assertions.assertThat(json.retrive("test")).isEqualTo(json)
+  }
+}

--- a/modules/fbs-core/api/src/test/scala/de/thm/ii/fbs/util/JsonWrapperTest.scala
+++ b/modules/fbs-core/api/src/test/scala/de/thm/ii/fbs/util/JsonWrapperTest.scala
@@ -68,6 +68,19 @@ class JsonWrapperTest {
     Assertions.assertThat(res).isEqualTo(expected)
   }
 
+  /**
+    * Tests JsonWrapper As Long
+    *
+    */
+  @Test
+  def jsonWrapperTestAsObject(): Unit = {
+    val json = getJsonObj
+    val expected = Option(mapper.createObjectNode())
+    val res = json.retrive("object").asObject()
+
+    Assertions.assertThat(res).isEqualTo(expected)
+  }
+
   private def getJsonObj = {
     val json = mapper.createObjectNode()
     json.put("string", "test")
@@ -81,6 +94,9 @@ class JsonWrapperTest {
 
     json.put("long", 1.toLong)
     json.putNull("emptyLong")
+
+    json.putObject("object")
+    json.putNull("emptyObject")
 
     json.putNull("null")
   }
@@ -97,11 +113,13 @@ class JsonWrapperTest {
     val resInt = json.retrive("emptyInt").asInt()
     val resBool = json.retrive("emptyBool").asBool()
     val resLong = json.retrive("emptyLong").asLong()
+    val resObj = json.retrive("emptyObject").asObject()
 
     Assertions.assertThat(resString).isEqualTo(expected)
     Assertions.assertThat(resInt).isEqualTo(expected)
     Assertions.assertThat(resBool).isEqualTo(expected)
     Assertions.assertThat(resLong).isEqualTo(expected)
+    Assertions.assertThat(resObj).isEqualTo(expected)
   }
 
   /**


### PR DESCRIPTION
The implementation of the JSON Warpper had a bug that converts `null` as the default value of the data type instead of None (e.g. a call to the function `.asText` would convert `null` to `Some('null')`, causing the error described in #883).

---

resolves #883 