### PR TITLE
build(deps): bump php8-pecl-mcrypt from 7 to 8 in /runtime-images/bash

### DIFF
--- a/runtime-images/bash/Dockerfile
+++ b/runtime-images/bash/Dockerfile
@@ -1,6 +1,6 @@
 FROM bash:5.2.12
 
-RUN apk add --no-cache php php-json php7-pecl-mcrypt build-base flex
+RUN apk add --no-cache php php-json php8-pecl-mcrypt build-base flex
 
 WORKDIR /root
 CMD ["sh"]


### PR DESCRIPTION
follow up #1008 which updates php to version 8