### PR TITLE
[Math-Parser] Add comparator support for exponent laws

### DIFF
--- a/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/SemanticAstComparator.kt
+++ b/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/SemanticAstComparator.kt
@@ -3,6 +3,9 @@ package de.thm.ii.fbs.mathParser
 import de.thm.ii.fbs.mathParser.ast.*
 import de.thm.ii.fbs.mathParser.transformers.*
 import java.math.RoundingMode
+import kotlin.reflect.KClass
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.primaryConstructor
 
 class SemanticAstComparator(
     decimals: Int = 2,
@@ -10,6 +13,7 @@ class SemanticAstComparator(
     ignoreNeutralElements: Boolean = false,
     applyInverseElements: Boolean = false,
     applyCommutativeLaw: Boolean = false,
+    applyExponentLaws: Boolean = false,
 ) {
     class Builder {
         private var decimals: Int = 2
@@ -17,15 +21,19 @@ class SemanticAstComparator(
         private var ignoreNeutralElements: Boolean = false
         private var applyInverseElements: Boolean = false
         private var applyCommutativeLaw: Boolean = false
+        private var applyExponentLaws: Boolean = false
 
         fun decimals(decimals: Int) = apply { this.decimals = decimals }
         fun roundingMode(roundingMode: RoundingMode) = apply { this.roundingMode = roundingMode }
         fun ignoreNeutralElements(ignoreNeutralElements: Boolean) = apply { this.ignoreNeutralElements = ignoreNeutralElements }
         fun applyInverseElements(applyInverseElements: Boolean) = apply { this.applyInverseElements = applyInverseElements }
         fun applyCommutativeLaw(applyCommutativeLaw: Boolean) = apply { this.applyCommutativeLaw = applyCommutativeLaw }
+        fun applyExponentLaws(applyExponentLaws: Boolean) = apply { this.applyExponentLaws = applyExponentLaws }
 
         fun build(): SemanticAstComparator =
-            SemanticAstComparator(decimals, roundingMode, ignoreNeutralElements, applyInverseElements, applyCommutativeLaw)
+            SemanticAstComparator(
+                decimals, roundingMode, ignoreNeutralElements, applyInverseElements, applyCommutativeLaw, applyExponentLaws
+            )
     }
 
     private val transformerConfig = TransformerConfig(decimals, roundingMode)
@@ -38,21 +46,44 @@ class SemanticAstComparator(
     private fun normalize(ast: Ast): Ast = transformer.transform(ast)
 
     private val transformer = run {
-        val transformers: MutableList<Transformer> = mutableListOf(NumberScalingTransformer(transformerConfig))
+        val cleaners: MutableList<KClass<*>> = mutableListOf()
         if (ignoreNeutralElements) {
-            transformers += listOf(NeutralElementTransformer(transformerConfig))
+            cleaners += listOf(NeutralElementTransformer::class)
         }
         if (applyInverseElements) {
-            transformers += listOf(InverseElementTransformer(transformerConfig))
+            cleaners += listOf(InverseElementTransformer::class)
         }
+
+        val transformers: MutableList<KClass<*>> = mutableListOf(NumberScalingTransformer::class)
         if (applyCommutativeLaw) {
             transformers += listOf(
-                SubReplacingTransformer(),
-                CommutativeLawTransformer()
+                SubReplacingTransformer::class,
+                DivisionReplacingTransformer::class,
+                CommutativeLawTransformer::class
             )
         }
+        if (applyExponentLaws) {
+            transformers += listOf(ExponentTransformer::class)
+        }
         ChainTransformer(
-            *transformers.toTypedArray()
+            *(
+                listOf(NumberScalingTransformer::class) +
+                cleaners +
+                transformers +
+                cleaners
+            ).map { createTransformer(it) as Transformer } .toTypedArray()
         )
+    }
+
+    private fun <T: Any> createTransformer(c: KClass<T>): T {
+        val constructor = c.primaryConstructor!!
+        val transformer = if (constructor.parameters.isEmpty()) {
+            constructor.call()
+        } else if (constructor.parameters.size == 1 && constructor.parameters[0].type == TransformerConfig::class.createType()) {
+            constructor.call(transformerConfig)
+        } else {
+            throw IllegalArgumentException("failed to invoke constructor for ${c.qualifiedName}")
+        }
+        return transformer
     }
 }

--- a/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/DebugTransformer.kt
+++ b/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/DebugTransformer.kt
@@ -1,0 +1,7 @@
+package de.thm.ii.fbs.mathParser.transformers
+
+import de.thm.ii.fbs.mathParser.ast.Ast
+
+class DebugTransformer : Transformer {
+    override fun transform(input: Ast): Ast = input.also { println(it.toDot()) }
+}

--- a/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/DivisionReplacingTransformer.kt
+++ b/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/DivisionReplacingTransformer.kt
@@ -1,0 +1,9 @@
+package de.thm.ii.fbs.mathParser.transformers
+
+import de.thm.ii.fbs.mathParser.ast.Operation
+import de.thm.ii.fbs.mathParser.ast.Operator
+import de.thm.ii.fbs.mathParser.transformers.rules.OperatorMatchingRule
+
+class DivisionReplacingTransformer(config: TransformerConfig) : RuleBasedTransformer(
+    OperatorMatchingRule(Operator.DIV) { Operation(Operator.MUL, it.left, Operation(Operator.DIV, config.exprFromInt(1), it.right)) },
+)

--- a/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/ExponentTransformer.kt
+++ b/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/ExponentTransformer.kt
@@ -1,0 +1,20 @@
+package de.thm.ii.fbs.mathParser.transformers
+
+import de.thm.ii.fbs.mathParser.ast.Num
+import de.thm.ii.fbs.mathParser.ast.Operation
+import de.thm.ii.fbs.mathParser.ast.Operator
+import de.thm.ii.fbs.mathParser.ast.UnaryOperation
+import de.thm.ii.fbs.mathParser.transformers.rules.OperandMatchingRule
+import de.thm.ii.fbs.mathParser.transformers.rules.OperatorMatchingRule
+
+class ExponentTransformer(config: TransformerConfig) : RuleBasedTransformer(
+    OperatorMatchingRule(Operator.EXP) {
+        if (it.right is UnaryOperation && it.right.operator == Operator.SUB)
+            Operation(
+                Operator.DIV,
+                config.exprFromInt(1),
+                Operation(Operator.EXP, it.left, it.right.target)
+            )
+        else it
+    },
+)

--- a/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/NeutralElementTransformer.kt
+++ b/modules/fbs-core/math-parser/src/main/kotlin/de/thm/ii/fbs/mathParser/transformers/NeutralElementTransformer.kt
@@ -8,4 +8,5 @@ class NeutralElementTransformer(config: TransformerConfig) : RuleBasedTransforme
     OperandMatchingRule(Operator.MUL, config.exprFromInt(1)),
     OperandMatchingRule(Operator.SUB, config.exprFromInt(0), matchLeftOperand = false),
     OperandMatchingRule(Operator.DIV, config.exprFromInt(1), matchLeftOperand = false),
+    OperandMatchingRule(Operator.EXP, config.exprFromInt(1), matchLeftOperand = false),
 )

--- a/modules/fbs-core/math-parser/src/test/kotlin/de/thm/ii/fbs/mathParser/SemanticAstComparatorTest.kt
+++ b/modules/fbs-core/math-parser/src/test/kotlin/de/thm/ii/fbs/mathParser/SemanticAstComparatorTest.kt
@@ -12,6 +12,7 @@ internal class SemanticAstComparatorTest {
         .ignoreNeutralElements(true)
         .applyInverseElements(true)
         .applyCommutativeLaw(true)
+        .applyExponentLaws(true)
         .build()
 
     @Test
@@ -115,6 +116,26 @@ internal class SemanticAstComparatorTest {
     }
 
     @Test
+    fun divisionAsFrac() {
+        assertTrue(
+            semanticAstComparator.compare(
+                MathParserHelper.parse("(6a+8b)/x"),
+                MathParserHelper.parse("1/x*(6a+8b)")
+            )
+        )
+    }
+
+    @Test
+    fun divisionAsFracWithExp() {
+        assertTrue(
+            semanticAstComparator.compare(
+                MathParserHelper.parse("(6a+8b)/x"),
+                MathParserHelper.parse("(6a+8b)*x^(-1)")
+            )
+        )
+    }
+
+    @Test
     fun multiplicationWithBracketsTest() {
         assertTrue(
             semanticAstComparator.compare(
@@ -125,12 +146,6 @@ internal class SemanticAstComparatorTest {
     }
 
     @Test
-    fun constructionTest() {
-        assertNotNull(SemanticAstComparator(2, RoundingMode.HALF_UP, ignoreNeutralElements = false, applyInverseElements = false, applyCommutativeLaw = false))
-        assertNotNull(SemanticAstComparator())
-    }
-
-    @Test
     fun multiplicationWithExponentTest() {
         assertTrue(
             semanticAstComparator.compare(
@@ -138,5 +153,11 @@ internal class SemanticAstComparatorTest {
                 MathParserHelper.parse("4*a^(-4)*b^4")
             )
         )
+    }
+
+    @Test
+    fun constructionTest() {
+        assertNotNull(SemanticAstComparator(2, RoundingMode.HALF_UP, ignoreNeutralElements = false, applyInverseElements = false, applyCommutativeLaw = false))
+        assertNotNull(SemanticAstComparator())
     }
 }

--- a/modules/fbs-core/math-parser/src/test/kotlin/de/thm/ii/fbs/mathParser/transformers/DebugTransformerTest.kt
+++ b/modules/fbs-core/math-parser/src/test/kotlin/de/thm/ii/fbs/mathParser/transformers/DebugTransformerTest.kt
@@ -1,0 +1,15 @@
+package de.thm.ii.fbs.mathParser.transformers
+
+import de.thm.ii.fbs.mathParser.ast.*
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class DebugTransformerTest {
+    private val simpleAst = Ast(Operation(Operator.ADD, Num(1), Num(1)))
+
+    @Test
+    fun transform() {
+        assertEquals(simpleAst, DebugTransformer().transform(simpleAst))
+    }
+}


### PR DESCRIPTION
I'm currently unhappy with the logic i used to instanciate the transformers for the `ChainTransformer` but I think it is better then passing `transformerConfig` to every Transformer. If anyone has a better idea let me know.

---

closes #1166 
