### PR TITLE
[Bash] Pin bash image to alpine 3.16

### DIFF
--- a/runtime-images/bash/Dockerfile
+++ b/runtime-images/bash/Dockerfile
@@ -1,4 +1,4 @@
-FROM bash:5.2.15
+FROM bash:5.2.15-alpine3.16
 
 RUN apk add --no-cache php php-json php8-pecl-mcrypt build-base flex
 


### PR DESCRIPTION
Alpine 3.17 appears to have [removed](https://pkgs.alpinelinux.org/packages?name=php8-pecl-mcrypt&branch=v3.17&repo=&arch=&maintainer=) the `php8-pecl-mcrypt` package. This is just a short term solution to prevent the CI from failing. In the long term an alternative for the package should be found.