### PR TITLE
ci(retry-codecov): Fixes an error that caused retry not to be executed

### DIFF
--- a/.github/actions/retry-codecov/action.yml
+++ b/.github/actions/retry-codecov/action.yml
@@ -21,11 +21,11 @@ runs:
     - run: sleep 1m
       shell: bash
       id: sleep-1
-      if: always() && steps.codecov.conclusion == 'failure'
+      if: always() && steps.codecov.outcome == 'failure'
     - uses: codecov/codecov-action@v3
       name: Upload Coverage Report (Retry 1)
       id: codecov-1
-      if: always() && steps.codecov.conclusion == 'failure'
+      if: always() && steps.codecov.outcome == 'failure'
       with:
         files: ${{ inputs.files }}
         flags: ${{ inputs.flags }}
@@ -34,11 +34,11 @@ runs:
     - run: sleep 5m
       shell: bash
       id: sleep-2
-      if: always() && steps.codecov-1.conclusion == 'failure'
+      if: always() && steps.codecov-1.outcome == 'failure'
     - uses: codecov/codecov-action@v3
       name: Upload Coverage Report (Retry 2)
       id: codecov-2
-      if: always() && steps.codecov-1.conclusion == 'failure'
+      if: always() && steps.codecov-1.outcome == 'failure'
       with:
         files: ${{ inputs.files }}
         flags: ${{ inputs.flags }}


### PR DESCRIPTION
In #1363, the `continue-on-error` option was added to prevent the job from failing if a retry was performed, but this leads to the bug that no retries were performed because the `conclusion` of the previous step was always `success`. To prevent this, the output `outcome` is now used (see [Github Docs](https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context) for more information).

---

- follow up #1363