### PR TITLE
adding mongodb and minio to core depencies in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     depends_on:
       - mysql1
       - runner
+      - mongodb
+      - minio
     ports:
       - "127.0.0.1:443:443"
       - "127.0.0.1:80:80"


### PR DESCRIPTION
Bug solved, log in is now reachable

![image](https://github.com/thm-mni-ii/feedbacksystem/assets/75866827/cb1187d7-9f3b-4d7a-97a2-d599828e0f4c)
